### PR TITLE
Added support for operator pipelining

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/sgx/SGXBaseRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/sgx/SGXBaseRunner.scala
@@ -29,11 +29,13 @@ import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.util.Utils
 
-import scala.reflect.{ClassTag}
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
 
 private[spark] abstract class SGXBaseRunner[IN: ClassTag, OUT: ClassTag](
                                            func: (Iterator[Any]) => Any,
-                                           evalType: Int) extends Logging {
+                                           evalType: Int,
+                                           funcs: ArrayBuffer[(Iterator[Any]) => Any]) extends Logging {
 
   private val conf = SparkEnv.get.conf
   private val bufferSize = conf.getInt("spark.buffer.size", 65536)
@@ -316,6 +318,9 @@ private[spark] abstract class SGXBaseRunner[IN: ClassTag, OUT: ClassTag](
 
 private[spark] object SGXFunctionType {
   val NON_UDF = 0
+  val PIPELINED = 1
+  val SHUFFLE_MAP = 2
+  val SHUFFLE_REDUCE = 3
   val BATCHED_UDF = 100
   def toString(sgxFuncType: Int): String = sgxFuncType match {
     case NON_UDF => "NON_UDF"
@@ -324,11 +329,11 @@ private[spark] object SGXFunctionType {
 }
 
 private[spark] object SpecialSGXChars {
-  val EMPTY_DATA = 0
+  val END_OF_FUNC_SECTION = 0
   val END_OF_DATA_SECTION = -1
   val SGX_EXCEPTION_THROWN = -2
   val TIMING_DATA = -3
   val END_OF_STREAM = -4
-  val NULL = -5
-  val START_ARROW_STREAM = -6
+  val EMPTY_DATA = -5
+  val NULL = -6
 }

--- a/core/src/main/scala/org/apache/spark/api/sgx/SGXRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/sgx/SGXRDD.scala
@@ -66,7 +66,7 @@ private[spark] object SGXRDD extends Logging {
       case _ =>
         val outSerArray = serializer.serialize(obj).array()
         dataOut.writeInt(outSerArray.length)
-        logDebug(s"SGX => Writing: ${outSerArray}")
+        logDebug(s"SGX => Writing: ${obj}")
         dataOut.write(outSerArray)
         // throw new SparkException("Unexpected element type " + other.getClass)
     }

--- a/core/src/main/scala/org/apache/spark/rdd/RDDBarrier.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDBarrier.scala
@@ -49,7 +49,7 @@ class RDDBarrier[T: ClassTag] private[spark] (rdd: RDD[T]) {
     new MapPartitionsRDD(
       rdd,
       (context: TaskContext, index: Int, iter: Iterator[T]) => cleanedF(iter),
-      preservesPartitioning,
+      preservesPartitioning = preservesPartitioning,
       isFromBarrier = true
     )
   }

--- a/core/src/main/scala/org/apache/spark/util/SGXUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/SGXUtils.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+
+object SGXUtils {
+  /** Closures used for SGX tests should be written here (not in Tests) as SGXRunner is using
+    *  classLoader to find the appropriate anonymous function */
+  val filterEvenNumFunc = (t: Int) => t % 2 == 0
+
+  val mapIncrementOneFunc = (v: Int) => v + 1
+  val mapMultiplyByTwoFunc = (v: Int) => v * 2
+
+  val mapPartitionsSum = (iter: Iterator[Int]) => Iterator(iter.sum)
+
+  val mapPartitionsWithIndex = (split: Int, iter: Iterator[Int]) => Iterator((split, iter.sum))
+  val mapToList = (iter: Array[Int]) => iter.toList
+
+  val flatMapOneToVal: (Int) => TraversableOnce[Int] = (x: Int) => 1 to x
+}


### PR DESCRIPTION
## Pipelined functions support
Addressing (#13) issue
* Multiple pipelined functions like filter, map, flatMap are now shipped to SGXWorker at once
* Added special Char (FUNC_END) to distinguish when function serialization is done
* Added special Func type (PIPELINED) when multiple functions should be applied
* TODO: support mapWithIndex special case and Glom

## How was this patch tested?
Extra unit test cases on RDDSuiteSGX

Please review http://spark.apache.org/contributing.html before opening a pull request.
