### PR TITLE
Supporting byPassMergeSort shuffle for SGX

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
@@ -17,32 +17,33 @@
 
 package org.apache.spark.shuffle.sort;
 
-import javax.annotation.Nullable;
-import java.io.*;
-import java.nio.channels.FileChannel;
-import java.util.Iterator;
-
-import scala.Option;
-import scala.Product2;
-import scala.collection.JavaConverters;
-import scala.reflect.ClassTag;
-import scala.reflect.ClassTag$;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closeables;
 import com.google.common.io.Files;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import org.apache.spark.*;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.channels.FileChannel;
+import java.util.Iterator;
+import javax.annotation.Nullable;
+import org.apache.commons.io.output.CloseShieldOutputStream;
+import org.apache.commons.io.output.CountingOutputStream;
+import org.apache.spark.Partitioner;
+import org.apache.spark.ShuffleDependency;
+import org.apache.spark.SparkConf;
+import org.apache.spark.TaskContext;
 import org.apache.spark.annotation.Private;
 import org.apache.spark.executor.ShuffleWriteMetrics;
+import org.apache.spark.internal.config.package$;
 import org.apache.spark.io.CompressionCodec;
 import org.apache.spark.io.CompressionCodec$;
 import org.apache.spark.io.NioBufferedFileInputStream;
-import org.apache.commons.io.output.CloseShieldOutputStream;
-import org.apache.commons.io.output.CountingOutputStream;
 import org.apache.spark.memory.TaskMemoryManager;
 import org.apache.spark.network.util.LimitedInputStream;
 import org.apache.spark.scheduler.MapStatus;
@@ -55,7 +56,13 @@ import org.apache.spark.storage.BlockManager;
 import org.apache.spark.storage.TimeTrackingOutputStream;
 import org.apache.spark.unsafe.Platform;
 import org.apache.spark.util.Utils;
-import org.apache.spark.internal.config.package$;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Option;
+import scala.Product2;
+import scala.collection.JavaConverters;
+import scala.reflect.ClassTag;
+import scala.reflect.ClassTag$;
 
 @Private
 public class UnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
@@ -205,6 +212,12 @@ public class UnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
         }
       }
     }
+  }
+
+  @Override
+  public void sgxWrite(scala.collection.Iterator<Product2<K, V>> records,
+      java.util.Map<K, Integer> recordMapping) throws IOException {
+    throw new RuntimeException("Not implemented yet!");
   }
 
   private void open() {

--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -129,6 +129,33 @@ class HashPartitioner(partitions: Int) extends Partitioner {
   override def hashCode: Int = numPartitions
 }
 
+
+/**
+  * A [[org.apache.spark.Partitioner]] that implements hash-based partitioning using
+  * Java's `Object.hashCode`.
+  *
+  * TODO: Make sure that the partitioner satisfies the pseudorandom properties we need
+  */
+class SGXPartitioner(partitions: Int) extends Partitioner {
+  require(partitions >= 0, s"Number of partitions ($partitions) cannot be negative.")
+
+  def numPartitions: Int = partitions
+
+  def getPartition(key: Any): Int = key match {
+    case null => 0
+    case _ => Utils.nonNegativeMod(key.hashCode, numPartitions)
+  }
+
+  override def equals(other: Any): Boolean = other match {
+    case h: HashPartitioner =>
+      h.numPartitions == numPartitions
+    case _ =>
+      false
+  }
+
+  override def hashCode: Int = numPartitions
+}
+
 /**
  * A [[org.apache.spark.Partitioner]] that partitions sortable records by range into roughly
  * equal ranges. The ranges are determined by sampling the content of the RDD passed in.

--- a/core/src/main/scala/org/apache/spark/api/sgx/SGXRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/sgx/SGXRDD.scala
@@ -44,7 +44,8 @@ private[spark] class SGXRDD(parent: RDD[_],
   val asJavaRDD: JavaRDD[Array[Byte]] = JavaRDD.fromRDD(this)
 
   override def compute(split: Partition, context: TaskContext): Iterator[Array[Byte]] = {
-    val runner = SGXRunner(func)
+    firstParent.iterator(split, context)
+    val runner = SGXRunner(func, if (parent.funcBuff.isEmpty) SGXFunctionType.NON_UDF else SGXFunctionType.PIPELINED, parent.funcBuff)
     runner.compute(firstParent.iterator(split, context), split.index, context)
   }
 

--- a/core/src/main/scala/org/apache/spark/api/sgx/SGXRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/sgx/SGXRunner.scala
@@ -45,8 +45,10 @@ private[spark] class SGXRunner(func: (Iterator[Any]) => Any, funcType: Int, func
   override protected def sgxWriterThread(env: SparkEnv,
                                          worker: Socket,
                                          inputIterator: Iterator[Array[Byte]],
-                                         partitionIndex: Int, context: TaskContext): WriterIterator = {
-    new WriterIterator(env, worker, inputIterator, partitionIndex, context) {
+                                         numOfPartitions: Int,
+                                         partitionIndex: Int,
+                                         context: TaskContext): WriterIterator = {
+    new WriterIterator(env, worker, inputIterator, numOfPartitions, partitionIndex, context) {
       /** Writes a command section to the stream connected to the SGX worker */
       override protected def writeFunction(dataOut: DataOutputStream): Unit = {
         logInfo(s"Ser ${funcs.size + 1} closures")

--- a/core/src/main/scala/org/apache/spark/deploy/worker/sgx/SGXWorker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/sgx/SGXWorker.scala
@@ -25,7 +25,7 @@ import org.apache.spark.api.sgx.{SGXException, SGXFunctionType, SGXRDD, SpecialS
 import org.apache.spark.internal.Logging
 import org.apache.spark.serializer._
 import org.apache.spark.util.Utils
-import org.apache.spark.{SparkConf, SparkException, TaskContext}
+import org.apache.spark.{SGXPartitioner, SparkConf, SparkException, TaskContext}
 
 import scala.collection.mutable
 import scala.reflect.ClassTag
@@ -52,6 +52,7 @@ private[spark] class SGXWorker(closuseSer: SerializerInstance, dataSer: Serializ
     val boundPort = inSock.readInt()
     val taskContext = TaskContext.get()
     val stageId = inSock.readInt()
+    val numOfPartitions = inSock.readInt()
     val partitionId = inSock.readInt()
     val attemptId = inSock.readInt()
     val taskAttemptId = inSock.readLong()

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleWriter.scala
@@ -29,6 +29,10 @@ private[spark] abstract class ShuffleWriter[K, V] {
   @throws[IOException]
   def write(records: Iterator[Product2[K, V]]): Unit
 
+  /** Write a sequence of encrypted records to this task's output following the given recordKey-Partition mapping */
+  @throws[IOException]
+  def sgxWrite(records: Iterator[Product2[K, V]], recordMapping: java.util.Map[K, Integer]): Unit
+
   /** Close this writer, passing along whether the map completed */
   def stop(success: Boolean): Option[MapStatus]
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
@@ -100,6 +100,11 @@ private[spark] class SortShuffleWriter[K, V, C](
       }
     }
   }
+
+  /** Write a sequence of encrypted records to this task's output following the given recordPartition mapping */
+  override def sgxWrite(records: Iterator[Product2[K, V]], recordMapping: java.util.Map[K, Integer]): Unit = {
+    throw new RuntimeException("Not implemented yet!")
+  }
 }
 
 private[spark] object SortShuffleWriter {

--- a/core/src/main/scala/org/apache/spark/util/SGXUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/SGXUtils.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.util
 
+import scala.collection.mutable
+
 
 object SGXUtils {
   /** Closures used for SGX tests should be written here (not in Tests) as SGXRunner is using
@@ -32,4 +34,17 @@ object SGXUtils {
   val mapToList = (iter: Array[Int]) => iter.toList
 
   val flatMapOneToVal: (Int) => TraversableOnce[Int] = (x: Int) => 1 to x
+
+
+  val groupBySum = (s: (String, scala.Iterable[Int])) => (s._1, (s._2.sum))
+
+
+  /**
+    * Dummy closure to maintain API consisent (used for shuffles - even though not used)
+    */
+  val toIteratorSizeSGXFunc = (itr: Iterator[Any]) => {
+    val result = new mutable.ArrayBuffer[Any]
+    itr.foreach(e => result.append(e))
+    result.toArray.iterator
+  }
 }

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuiteSGX.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuiteSGX.scala
@@ -36,7 +36,7 @@ class RDDSuiteSGX extends SparkFunSuite {
     tempDir = Utils.createTempDir()
     conf = new SparkConf().setMaster("local").setAppName("RDD SGX suite test")
     conf.enableSGXWorker()
-    conf.enableSGXDebug()
+//    conf.enableSGXDebug()
     conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
     sc = new SparkContext(conf)
   }
@@ -88,13 +88,13 @@ class RDDSuiteSGX extends SparkFunSuite {
     assert(nums.flatMap(SGXUtils.flatMapOneToVal).collect().toList === List(1, 1, 2, 1, 2, 3, 1, 2, 3, 4))
   }
 
-  test("SGX shuffle operation") {
+  test("SGX BypassMergeSort shuffle operation") {
     val kvPairs = sc.parallelize(Array(
       ("USA", 1), ("USA", 2), ("UK", 6), ("UK", 9),
       ("India", 4), ("India", 1), ("USA", 8), ("USA", 3),
       ("UK", 5), ("UK", 1), ("India", 4), ("India", 9)
-    ), 1)
-    val res = kvPairs.groupByKey().map(s => (s._1, (s._2.sum)))
+    ), 2)
+    val res = kvPairs.groupByKey().map(SGXUtils.groupBySum)
     val resK = res.collect
     assert(resK.size == 3)
   }


### PR DESCRIPTION
Addressing #15 

* Introducing new SHUFFLE_MAP type for bypassMerge sort shuffle
* Adding numOfPartitions as part of SGX RDD (needed by the shuffle partitioner)
* Introducing SGX partitioner - hash-based for now (to be changed by any pseudorandom function we want)
* Introducing sgxWrite interface as part of Shuffle writer, when SGX is enabled we use this path instead. The method takes as arguments both the encrypted records AND the record-partition mapping (recordMapping) as returned by the enclave worker
*  Handling SHUFFLE_MAP_BYPASS task type in SGX worker - return a record-partition mapping iterator
*  ShuffleMapTask checks if SGX is enabled and calls the appropriate shuffle interface
* ByPassSort shuffle test case with multiple partitions